### PR TITLE
Fix project details being only accessable to users

### DIFF
--- a/api/src/controllers/project.controller.ts
+++ b/api/src/controllers/project.controller.ts
@@ -83,7 +83,7 @@ export default class ProjectController {
   @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Not found' })
   @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
   async findOne(@Req() req, @Param('projectId') projectId: string) {
-    const user = this.auth.getRequestUserOrClient(req, { mustBeUser: true });
+    const user = this.auth.getRequestUserOrClient(req);
     const membership = await this.auth.authorizeProjectAction(user, projectId, ProjectAction.ViewProject);
     return {
       data: {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

1.  Contributor license agreement
    For us it's important to have the agreement of our contributors to use their work, whether it be code or documentation. Therefore, we are asking all contributors to sign a contributor license agreement (CLA) as commonly accepted in most open source projects. **Just open the pull request and our CLA bot will prompt you briefly.**

2.  Please check our [contribution guidelines](https://docs.traduora.co/docs/contributing#review-process-for-this-repo) for some help in the process.

# PR Content
- Changed the `/projects/{projectId}` endpoint to be only accessable for users.
  - It doesn't really makes sense that the project information can only be viewed by users and not by the client
  - There are also good uses for this endpoint to be accessable for clients, e.g. a translation management in a application with multiple traduora projects where the credentials need to be identified from where they are.